### PR TITLE
Submit form on Enter in tag field

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -161,6 +161,12 @@ $(() => {
                 return false;
               },
               select : (e, ui) => {
+                if (e.keyCode === $.ui.keyCode.ENTER) {
+                  // enter should submit the form, not autocomplete
+                  $form.trigger('submit');
+                  return false;
+                }
+
                 let terms = util.split(e.target.value);
                 // remove the current input
                 terms.pop();


### PR DESCRIPTION
Addresses #23.

Basic input idea:

- `Tab` is used for autocomplete.
- `Enter` anywhere in the form should submit the form.

Before this commit, `Enter` was the same as `Tab` if the autocomplete
form was open, which could be confusing. -POLM