### PR TITLE
Use shift+enter to submit form from description

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -102,6 +102,13 @@ $(() => {
         setAlertDanger(Message.isNotAuthenticated);
         $bookmark.prop('disabled', true);
       } else {
+        // set up keyboard form submission
+        $description.on('keydown', e => {
+          if (e.key === "Enter" && e.shiftKey) {
+            $form.trigger('submit');
+            return false;
+          }
+        })
         API.getPost(response.url, authToken).then(data => {
           if (data.posts.length !== 0) {
             let post = data.posts.shift();


### PR DESCRIPTION
Hello. It has been many years since my last PR (#30); thanks for integrating it and doing a release. I have another small change. 

The change in this PR makes it so that pushing shift+enter in the `description` field will submit the form, which makes it so bookmarks can be added with descriptions entirely from the keyboard. I find this useful when going through backlogs of tabs.